### PR TITLE
Add labels to Dockerfile

### DIFF
--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,5 +1,4 @@
 FROM phusion/baseimage
-MAINTAINER Michał Piotrowski <michal.piotrowski@erlang-solutions.com>
 
 COPY ./member/clusterize /clusterize
 COPY ./member/start.sh /start.sh
@@ -7,5 +6,18 @@ COPY ./member/mongooseim.tar.gz mongooseim.tar.gz
 VOLUME ["/member", "/var/lib/mongooseim"]
 
 EXPOSE 4369 5222 5269 5280 9100
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.name='MongooseIM' \
+      org.label-schema.description='MongooseIM is a mobile messaging platform with focus on performance and scalability' \
+      org.label-schema.url='https://www.erlang-solutions.com/products/mongooseim.html' \
+      org.label-schema.vcs-url='https://github.com/esl/MongooseIM' \
+      org.label-schema.vendor='Erlang Solutions' \
+      org.label-schema.schema-version='1.0' \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.version=$VERSION
 
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
Adds labels to docker image as proposed in http://label-schema.org/rc1/

Example labels looks like this:

```json
"Labels": {
                "org.label-schema.build-date": "2017-03-02T09:08:01Z",
                "org.label-schema.description": "MongooseIM is a mobile messaging platform with focus on performance and scalability",
                "org.label-schema.name": "MongooseIM",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://www.erlang-solutions.com/products/mongooseim.html",
                "org.label-schema.vcs-ref": "47ba4c6",
                "org.label-schema.vcs-url": "https://github.com/esl/MongooseIM",
                "org.label-schema.vendor": "Erlang Solutions",
                "org.label-schema.version": "2.1.0beta1.3"
            }
```