### PR TITLE
Add ODBC-related build and runtime dependencies

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libexpat1-dev \
     libpam0g-dev \
+    unixodbc-dev \
     wget && \
     wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
     dpkg -i erlang-solutions_1.0_all.deb && \

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -19,7 +19,14 @@ LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.version=$VERSION
 
-RUN apt-get update && apt-get install -y iproute2 netcat inetutils-ping telnet && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install -y \
+        iproute2 \
+        netcat \
+        inetutils-ping \
+        telnet \
+        unixodbc \
+        tdsodbc \
+        odbc-postgresql && \
+        apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENTRYPOINT ["/start.sh"]


### PR DESCRIPTION
These are required after MongooseIM has switched to using eodbc as ODBC driver.