### PR TITLE
Allow to build with selected Erlang/OTP version

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,7 @@
 FROM phusion/baseimage
 
+ARG OTP_VSN=20.3
+
 # required packages
 RUN apt-get update && apt-get install -y \
     bash \
@@ -21,7 +23,7 @@ RUN apt-get update && apt-get install -y \
     wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
     dpkg -i erlang-solutions_1.0_all.deb && \
     apt-get update && \
-    apt-get install -y esl-erlang=1:18.3.4 && \
+    apt-get install -y esl-erlang=1:$OTP_VSN && \
     apt-get clean
 
 COPY ./builder/build.sh /build.sh

--- a/README.md
+++ b/README.md
@@ -17,20 +17,34 @@ If customised images are needed, following documentation may be useful.
 
 ### Build a MongooseIM tarball
 
-#### The builder bot
+#### The builder container
 
-In order to build MongooseIM tarball a mongooseim-builder needs to be started.
-It's important to mount the container `/builds` volume as the MongooseIM tarball
-will be placed there after the build.
-For simplicity it's assumed that env var `VOLUMES` is exported and set to an existing
-absolute path, f.e: `pwd`
+In order to build MongooseIM tarball a builder image and container need to be created.
+You can create an image by running the following command:
+
+```
+docker build -f Dockerfile.builder -t mongooseim-builder .
+```
+
+After that you can run the builder container.
+It's important to mount the container's `/builds` directory as a volume because MongooseIM tarball will be placed there after the build.
+For simplicity it's assumed that env var `VOLUMES` is exported and set to an existing absolute path, f.e: `pwd`
 
 ```
 docker run -d --name mongooseim-builder -h mongooseim-builder \
        -v ${VOLUMES}/builds:/builds mongooseim/mongooseim-builder
 ```
 
-or just
+##### Modifying Erlang/OTP version
+
+You can modify which Erlang/OTP version is used by MongooseIM when creating a builder image by providing `OTP_VSN` build argument:
+
+
+```
+docker build --build-arg OTP_VSN=19.3.6 -f Dockerfile.builder -t mongooseim-builder:otp19.3.6 .
+```
+
+By default the builder will use Erlang/OTP 20.3.
 
 
 #### Building MongooseIM


### PR DESCRIPTION
After this is merged we should probably push builder images all major Erlang versions supported by MongooseIM: 18, 19 and 20.