### PR TITLE
Fix CLUSTER_WITH variable test

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -54,7 +54,7 @@ function run() {
 }
 
 DEFAULT_CLUSTERING=0
-if [ "${CLUSTER_WITH}" = "" ]; then
+if [ x"${CLUSTER_WITH}" = x"" ]; then
     CLUSTER_WITH="mongooseim@${HOSTNAME%-?}-1"
     DEFAULT_CLUSTERING=1
 fi


### PR DESCRIPTION
This change allows to actually provide / override CLUSTER_WITH variable.
Without this change the 'if' in question was always evaluating to 'true'