### PR TITLE
Replace cp to simlink

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -28,10 +28,10 @@ ESCRIPT=`find ${ROOT_DIR} -name escript`
 ETC_DIR=${ROOT_DIR}/etc
 
 # if there are predefined config files available, use them
-FILES=( "/member/mongooseim.cfg" "/member/app.config" "/member/vm.args" "/member/vm.dist.args" )
+FILES=( "mongooseim.cfg" "app.config" "vm.args" "vm.dist.args" )
 for file in "${FILES[@]}"
 do
-    [ -f "${file}" ] && cp "${file}" ${ETC_DIR}/
+    [ -f "/member/${file}" ] && ln -sf "/member/${file}" ${ETC_DIR}/${file}
 done
 
 # make sure proper node name is used


### PR DESCRIPTION
We use this image in Kubernetes. Currently I have mount configmaps to /member/. But when configmap changes we need restart container as a result we lost active connections.

I recommend replacing copy to symlink creation. In this case we could change configs without restarting container.