### PR TITLE
Pattern Matching mistake

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -67,7 +67,7 @@ if [ x"${CLUSTER_WITH}" = x"" ]; then
     # For long hostname - HOST_TAIL will contain all of it but the leading segment
     HOST_TAIL=$(echo $NODE_HOST | sed -e 's/^[^.]*//')
 
-    CLUSTER_WITH="${NODE_NAME}@${HOSTNAME_SHORT%-?}-${MASTER_ORDINAL}${HOST_TAIL}"
+    CLUSTER_WITH="${NODE_NAME}@${HOSTNAME_SHORT%-*}-${MASTER_ORDINAL}${HOST_TAIL}"
     DEFAULT_CLUSTERING=1
 fi
 


### PR DESCRIPTION
The current pattern doesn't work for cluster more than 10 nodes. For example:
```
HOSTNAME_SHORT=mongooseim-12
echo ${HOSTNAME_SHORT%-?}
```
Returns mongooseim-12 instead of mongooseim
My PR fix this issue.