### PR TITLE
replacement for exometer_report_graphite prefix

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -41,6 +41,7 @@ cat ${ETC_DIR}/vm.args
 echo "app.config"
 sed -i -e "s,%{mnesia.*,{mnesia\, [{dir\, \"${MNESIA_DIR}\"}]}\,," ${ETC_DIR}/app.config
 sed -i -e "s,{log_root.*,{log_root\, \"/var/log/mongooseim\"}\,," ${ETC_DIR}/app.config
+sed -i -e "s,{prefix.*,{prefix\, \"${HOSTNAME}\"}\,," ${ETC_DIR}/app.config
 cat ${ETC_DIR}/app.config
 
 echo "vm.dist.args"


### PR DESCRIPTION
I am running mongooseim in kubernetes and use exometer_report_graphite for monitoring. I need different  prefixes for different mongooseim pods. I am recommended use hostname as a prefix for graphite