### PR TITLE
Use baseimage:master - currently Ubuntu 18.04

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,6 +1,6 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:master
 
-ARG OTP_VSN=20.3
+ARG OTP_VSN=22.3-1
 
 # required packages
 RUN apt-get update && apt-get install -y \
@@ -19,9 +19,11 @@ RUN apt-get update && apt-get install -y \
     libexpat1-dev \
     libpam0g-dev \
     unixodbc-dev \
+    gnupg \
+    zlib1g-dev \
     wget && \
-    wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && \
-    dpkg -i erlang-solutions_1.0_all.deb && \
+    wget http://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
+    dpkg -i erlang-solutions_2.0_all.deb && \
     apt-get update && \
     apt-get install -y esl-erlang=1:$OTP_VSN && \
     apt-get clean

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:master
 
 COPY ./member/start.sh /start.sh
 ADD ./member/mongooseim.tar.gz /usr/lib/
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install -y \
         telnet \
         unixodbc \
         tdsodbc \
+        zlib1g \
         odbc-postgresql && \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This PR changes the base image used for MongooseIM dokcer image to a newer one, based on Ubuntu 18.04