### PR TITLE
Adding mongooseim.toml config file compatibility for MongooseIM 4.0.0

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -27,7 +27,7 @@ ESCRIPT=`find ${ROOT_DIR} -name escript`
 ETC_DIR=${ROOT_DIR}/etc
 
 # if there are predefined config files available, use them
-FILES=( "mongooseim.cfg" "app.config" "vm.args" "vm.dist.args" )
+FILES=( "mongooseim.cfg" "mongooseim.toml" "app.config" "vm.args" "vm.dist.args" )
 for file in "${FILES[@]}"
 do
     [ -f "/member/${file}" ] && ln -sf "/member/${file}" ${ETC_DIR}/${file}


### PR DESCRIPTION
Current start.sh script will not copy the new toml config file for MongooseIM 4.0.0 which is required to make user defined configuration work if using the new format. 

Simply adding the new mongooseim.toml to the list of overridable configuration files in start.sh makes it work.
