### PR TITLE
Update Ubuntu version

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:18.04-1.0.0
+FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
 
 ARG OTP_VSN=23.1-1
 

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:18.04-1.0.0
+FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
 
 COPY ./member/start.sh /start.sh
 ADD ./member/mongooseim.tar.gz /usr/lib/


### PR DESCRIPTION
Phusion hasn't released a final Ubuntu 20.04 version, it's so far in alpha, but it does the job. I can start the container and connect users on XMPP and make them have basic chats.