### PR TITLE
Update baseimage:focal to stable multi-build version

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
+FROM phusion/baseimage:focal-1.0.0
 
 ARG OTP_VSN=23.1-1
 

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
+FROM phusion/baseimage:focal-1.0.0
 
 COPY ./member/start.sh /start.sh
 ADD ./member/mongooseim.tar.gz /usr/lib/


### PR DESCRIPTION
Just updating the base image to stable version (btw most recent is 1.3.0). Also, not specifying architecture on the base image allows m1 machines to build things locally. People can always use `platform` flag to force amd if needed.