### PR TITLE
Add mongooseim into path

### DIFF
--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,10 +1,23 @@
 FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
 
-COPY ./member/start.sh /start.sh
-ADD ./member/mongooseim.tar.gz /usr/lib/
+ENTRYPOINT ["/start.sh"]
 VOLUME ["/member", "/var/lib/mongooseim"]
 
 EXPOSE 4369 5222 5269 5280 9100
+
+# Allow an easy access to mongooseim and mongooseimctl commands
+ENV PATH="${PATH}:/usr/lib/mongooseim/bin"
+
+RUN apt-get update && apt-get install -y \
+        libssl1.1 \
+        iproute2 \
+        netcat \
+        inetutils-ping \
+        telnet \
+        unixodbc \
+        tdsodbc \
+        odbc-postgresql && \
+        apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -21,15 +34,5 @@ LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.vcs-ref-desc=$VCS_REF_DESC \
       org.label-schema.version=$VERSION
 
-RUN apt-get update && apt-get install -y \
-        libssl1.1 \
-        iproute2 \
-        netcat \
-        inetutils-ping \
-        telnet \
-        unixodbc \
-        tdsodbc \
-        odbc-postgresql && \
-        apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENTRYPOINT ["/start.sh"]
+COPY ./member/start.sh /start.sh
+ADD ./member/mongooseim.tar.gz /usr/lib/


### PR DESCRIPTION
Two simple changes:
- reorder commands, so deps are installed once (probably useless for circle-ci, but ok for local dev)
- add mongooseim into path, so we don't need to use long paths when exec into a container.