### PR TITLE
Version use new base image of docker version

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
+FROM phusion/baseimage:jammy-1.0.1
 
 ARG OTP_VSN=23.1-1
 

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0-alpha1-amd64
+FROM phusion/baseimage:jammy-1.0.1
 
 COPY ./member/start.sh /start.sh
 ADD ./member/mongooseim.tar.gz /usr/lib/

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -22,7 +22,7 @@ LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.version=$VERSION
 
 RUN apt-get update && apt-get install -y \
-        libssl1.1 \
+        libssl3 \
         iproute2 \
         netcat \
         inetutils-ping \


### PR DESCRIPTION
Uses ubuntu 22.04 instead of 20.04 to match what we use on CircleCI.
Because we build release in CircleCI docker executor to speed things up.

PR to MIM: https://github.com/esl/MongooseIM/pull/3943