### PR TITLE
Add CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,3 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./build.sh
+      - run: ./smoke_test.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: ci
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Build
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./build.sh

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,11 +1,10 @@
-FROM phusion/baseimage:jammy-1.0.1
-
-ARG OTP_VSN=23.1-1
+ARG OTP_VSN=25.2
+FROM chrzaszcz/cimg-erlang:$OTP_VSN
 
 # required packages
-RUN apt-get update && apt-get install -y \
+# remove a weird lock file
+RUN sudo apt-get update && sudo apt-get install -y \
     bash \
-    bash-completion \
     wget \
     git \
     make \
@@ -20,13 +19,8 @@ RUN apt-get update && apt-get install -y \
     libpam0g-dev \
     unixodbc-dev \
     gnupg \
-    zlib1g-dev \
-    wget && \
-    wget http://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
-    dpkg -i erlang-solutions_2.0_all.deb && \
-    apt-get update && \
-    apt-get install -y esl-erlang=1:$OTP_VSN && \
-    apt-get clean
+    zlib1g-dev && \
+    sudo apt-get clean
 
 COPY ./builder/build.sh /build.sh
 VOLUME /builds

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,7 +2,6 @@ ARG OTP_VSN=25.2
 FROM chrzaszcz/cimg-erlang:$OTP_VSN
 
 # required packages
-# remove a weird lock file
 RUN sudo apt-get update && sudo apt-get install -y \
     bash \
     wget \

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -36,4 +36,4 @@ LABEL org.label-schema.name='MongooseIM' \
 COPY ./member/start.sh /start.sh
 ADD ./member/mongooseim.tar.gz /usr/lib/
 
-ENTRYPOINT ["/start.sh"]
+CMD ["/start.sh"]

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -4,6 +4,9 @@ VOLUME ["/member", "/var/lib/mongooseim"]
 
 EXPOSE 4369 5222 5269 5280 9100
 
+# Allow an easy access to mongooseim and mongooseimctl commands
+ENV PATH="${PATH}:/usr/lib/mongooseim/bin"
+
 RUN apt-get update && apt-get install -y \
         libssl3 \
         iproute2 \

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,10 +1,19 @@
 FROM phusion/baseimage:jammy-1.0.1
 
-COPY ./member/start.sh /start.sh
-ADD ./member/mongooseim.tar.gz /usr/lib/
 VOLUME ["/member", "/var/lib/mongooseim"]
 
 EXPOSE 4369 5222 5269 5280 9100
+
+RUN apt-get update && apt-get install -y \
+        libssl3 \
+        iproute2 \
+        netcat \
+        inetutils-ping \
+        telnet \
+        unixodbc \
+        tdsodbc \
+        odbc-postgresql && \
+        apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -21,15 +30,7 @@ LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.vcs-ref-desc=$VCS_REF_DESC \
       org.label-schema.version=$VERSION
 
-RUN apt-get update && apt-get install -y \
-        libssl3 \
-        iproute2 \
-        netcat \
-        inetutils-ping \
-        telnet \
-        unixodbc \
-        tdsodbc \
-        odbc-postgresql && \
-        apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY ./member/start.sh /start.sh
+ADD ./member/mongooseim.tar.gz /usr/lib/
 
 ENTRYPOINT ["/start.sh"]

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-# Build a builder image (contains erlang and build tooks)
+# Build a builder image (contains erlang and the build tools)
 docker build -f Dockerfile.builder -t mongooseim-builder .
 
 # Create a volume for the result tarballs

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+# Build a builder image (contains erlang and build tooks)
+docker build -f Dockerfile.builder -t mongooseim-builder .
+
+# Create a volume for the result tarballs
+docker volume create mongooseim-builds || echo "Probably already created volume"
+
+# Build MongooseIM release
+docker run --rm -v mongooseim-builds:/builds -e TARBALL_NAME=mongooseim.tar.gz mongooseim-builder /build.sh
+
+# Copy our build artifact
+CID=$(docker run --rm -d -v mongooseim-builds:/builds busybox sleep 1000)
+docker cp $CID:/builds/mongooseim.tar.gz ./member/
+docker rm -f $CID
+
+# Build a final image
+docker build -f Dockerfile.member -t mongooseim .

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -29,7 +29,8 @@ build () {
         git describe --always >> ${version_file}
     local build_success=$?
     local timestamp=$(date +%F_%H%M%S)
-    local tarball="mongooseim-${name}-${commit}-${timestamp}.tar.gz"
+    local tarball_default="mongooseim-${name}-${commit}-${timestamp}.tar.gz"
+    local tarball=${TARBALL_NAME:-$tarball_default}
     if [ $build_success = 0 ]; then
         cd _build/prod/rel && \
             tar cfzh ${BUILDS}/${tarball} mongooseim && \
@@ -43,4 +44,5 @@ build () {
     exit 2
 }
 
+sudo chmod 777 "$BUILDS"
 build $@

--- a/member/start.sh
+++ b/member/start.sh
@@ -61,6 +61,9 @@ function run() {
     fi
 }
 
+# Run initial configuration scripts
+mongooseimctl bootstrap
+
 DEFAULT_CLUSTERING=0
 if [ x"${CLUSTER_WITH}" = x"" ]; then
     # For short hostname - HOST_TAIL will be empty

--- a/member/start.sh
+++ b/member/start.sh
@@ -62,7 +62,9 @@ function run() {
 }
 
 # Run initial configuration scripts
-mongooseimctl bootstrap
+if [ x"${BOOTSTRAP_ENABLED}" = "true" ] || [ "${BOOTSTRAP_ENABLED}" = "1" ]; then
+    mongooseimctl bootstrap
+fi
 
 DEFAULT_CLUSTERING=0
 if [ x"${CLUSTER_WITH}" = x"" ]; then

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -5,7 +5,7 @@ IMAGE=${IMAGE:-mongooseim}
 
 echo "Start MongooseIM container"
 docker rm -f mongooseim-smoke
-docker run --name=mongooseim-smoke -e JOIN_CLUSTER=false -d mongooseim
+docker run --name=mongooseim-smoke -e JOIN_CLUSTER=false -e BOOTSTRAP_ENABLED=true -d mongooseim
 
 CTL="docker exec mongooseim-smoke mongooseimctl"
 
@@ -15,8 +15,8 @@ $CTL started
 echo "Checking status via 'mongooseimctl status'"
 $CTL status
 
-echo "Trying to register a user with 'mongooseimctl register localhost a_password'"
-$CTL register localhost a_password
+echo "Trying to register a user"
+$CTL account registerUser --domain localhost --password a_password
 
 echo "Check if bootstap script works"
 docker logs mongooseim-smoke | grep "Hello from"

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+IMAGE=${IMAGE:-mongooseim}
+
+echo "Start MongooseIM container"
+docker rm -f mongooseim-smoke
+docker run --name=mongooseim-smoke -e JOIN_CLUSTER=false -d mongooseim
+
+CTL="docker exec mongooseim-smoke mongooseimctl"
+
+echo "Wait for Mongooseim to get started"
+$CTL started
+
+echo "Checking status via 'mongooseimctl status'"
+$CTL status
+
+echo "Trying to register a user with 'mongooseimctl register localhost a_password'"
+$CTL register localhost a_password
+
+echo "Check if bootstap script works"
+docker logs mongooseim-smoke | grep "Hello from"
+
+echo "Stop and remove mongooseim-smoke container"
+docker rm -f mongooseim-smoke
+


### PR DESCRIPTION
This repo historically use two stage build, before Docker stages were built-in feature.
There is some info how to use it in README.
Except, no one-line-command to use it (so, we can test building locally).

This PR adds this one-liner as a `./build.sh` script. Be aware, it is not called when we build MongooseIM images in the main repo.
But to ensure that script is actually working, I've added CI task into this repo.


Also, added a couple of tweaks to make life easier.

Changes:
- Add github actions simple test script so we don't break something.
- Reorder commands, so deps are installed once (probably useless for circle-ci, but ok for local dev)
- Add mongooseim into path, so we don't need to use long paths when exec into a container.
- Use CMD instead of ENTRYPOINT.
- Execute `mongooseim bootstrap`.
- Add a smoke test.