### PR TITLE
Support multi-platform builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,11 @@ on:
 jobs:
   test:
     name: Build
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
+      - uses: docker-practice/actions-setup-docker@master
+        with:
+          docker_version: 23.0.1
       - uses: actions/checkout@v2
       - run: ./build.sh
       - run: ./smoke_test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+member/start.sh
+member/build.log
+member/*.tar.gz
+*~

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
-ARG OTP_VSN=25.2
-FROM chrzaszcz/cimg-erlang:$OTP_VSN
+ARG OTP_VSN=25.2.3
+FROM mongooseim/cimg-erlang:$OTP_VSN
 
 # required packages
 RUN sudo apt-get update && sudo apt-get install -y \
@@ -24,4 +24,4 @@ RUN sudo apt-get update && sudo apt-get install -y \
 COPY ./builder/build.sh /build.sh
 VOLUME /builds
 
-CMD ["/sbin/my_init"]
+CMD ["/build.sh"]

--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -22,6 +22,8 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_REF_DESC
 ARG VERSION
+ARG TARGETARCH
+
 LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.description='MongooseIM is a mobile messaging platform with focus on performance and scalability' \
       org.label-schema.url='https://www.erlang-solutions.com/products/mongooseim.html' \
@@ -34,6 +36,6 @@ LABEL org.label-schema.name='MongooseIM' \
       org.label-schema.version=$VERSION
 
 COPY ./member/start.sh /start.sh
-ADD ./member/mongooseim.tar.gz /usr/lib/
+ADD ./member/mongooseim-$TARGETARCH.tar.gz /usr/lib/
 
 CMD ["/start.sh"]

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,11 @@ docker build -f Dockerfile.builder -t mongooseim-builder .
 docker volume create mongooseim-builds || echo "Probably already created volume"
 
 # Build MongooseIM release
-docker run --rm -v mongooseim-builds:/builds -e TARBALL_NAME=mongooseim.tar.gz mongooseim-builder /build.sh
+docker run --rm -v mongooseim-builds:/builds -e TARBALL_NAME=mongooseim mongooseim-builder
 
-# Copy our build artifact
+# Copy the latest build artifact
 CID=$(docker run --rm -d -v mongooseim-builds:/builds busybox sleep 1000)
-docker cp $CID:/builds/mongooseim.tar.gz ./member/
+docker cp $CID:/builds/. ./member/
 docker rm -f $CID
 
 # Build a final image

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -6,7 +6,6 @@
 
 BUILDS=${BUILDS:-/builds}
 LOGFILE=${LOGFILE:-$BUILDS/build.log}
-TIMESTAMP=$(date +%F_%H%M%S)
 
 log () {
     echo \[$(date '+%F %H:%M:%S')\] $@
@@ -29,8 +28,8 @@ build () {
         git describe --always >> ${version_file}
     local build_success=$?
     local timestamp=$(date +%F_%H%M%S)
-    local tarball_default="mongooseim-${name}-${commit}-${timestamp}.tar.gz"
-    local tarball=${TARBALL_NAME:-$tarball_default}
+    local tarball_default="mongooseim-${name}-${commit}-${timestamp}"
+    local tarball=${TARBALL_NAME:-$tarball_default}-${ARCH}.tar.gz
     if [ $build_success = 0 ]; then
         cd _build/prod/rel && \
             tar cfzh ${BUILDS}/${tarball} mongooseim && \

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 set -e
-IMAGE=${IMAGE:-mongooseim}
+IMAGE_TAG=${IMAGE_TAG:-mongooseim}
 
 echo "Start MongooseIM container"
 docker rm -f mongooseim-smoke
-docker run --name=mongooseim-smoke -e JOIN_CLUSTER=false -e BOOTSTRAP_ENABLED=true -d mongooseim
+docker run --name=mongooseim-smoke -e JOIN_CLUSTER=false -e BOOTSTRAP_ENABLED=true -d $IMAGE_TAG
 
 CTL="docker exec mongooseim-smoke mongooseimctl"
 


### PR DESCRIPTION
Support using `Dockerfile.member` to build a multi-platform image with `docker buildx`.
To make it work, tarballs must have the architecture in their names.