### PR TITLE
Do not print configs on start

### DIFF
--- a/member/start.sh
+++ b/member/start.sh
@@ -38,17 +38,26 @@ do
 done
 
 # make sure proper node name is used
-echo "vm.args:"
 sed -i -E -e "s/^-s?name.*$/-${NODE_TYPE} ${NODE}/" ${ETC_DIR}/vm.args
-cat ${ETC_DIR}/vm.args
 
-echo "app.config"
+# Change paths
 sed -i -e "s,%{mnesia.*,{mnesia\, [{dir\, \"${MNESIA_DIR}\"}]}\,," ${ETC_DIR}/app.config
 sed -i -e "s,{log_root.*,{log_root\, \"/var/log/mongooseim\"}\,," ${ETC_DIR}/app.config
-cat ${ETC_DIR}/app.config
 
-echo "vm.dist.args"
-cat ${ETC_DIR}/vm.dist.args
+# Set env variable PRINT_CONFIG_FILES_ON_START=true to debug configs
+if [ "${PRINT_CONFIG_FILES_ON_START}" = "true" ]; then
+    echo "vm.args:"
+    cat ${ETC_DIR}/vm.args
+
+    echo "app.config:"
+    cat ${ETC_DIR}/app.config
+
+    echo "vm.dist.args:"
+    cat ${ETC_DIR}/vm.dist.args
+
+    echo "mongooseim.toml:"
+    cat ${ETC_DIR}/mongooseim.toml
+fi
 
 #file "${MNESIA_DIR}/schema.DAT"
 

--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -21,6 +21,9 @@ $CTL account registerUser --domain localhost --password a_password
 echo "Check if bootstap script works"
 docker logs mongooseim-smoke | grep "Hello from"
 
+echo "Print full logs"
+docker logs mongooseim-smoke
+
 echo "Stop and remove mongooseim-smoke container"
 docker rm -f mongooseim-smoke
 


### PR DESCRIPTION
Do not print configs on start
If you want configs to be printed, use PRINT_CONFIG_FILES_ON_START=true env var

Tested on CI with smoke test