### PR TITLE
Change member's base docker image

### DIFF
--- a/Dockerfile.member
+++ b/Dockerfile.member
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.4
+FROM ubuntu:oracular
 
 VOLUME ["/member", "/var/lib/mongooseim"]
 
@@ -10,28 +10,12 @@ ENV PATH="${PATH}:/usr/lib/mongooseim/bin"
 RUN apt-get update && apt-get install -y \
         libssl3 \
         iproute2 \
-        netcat \
+        netcat-openbsd \
         inetutils-ping \
         telnet \
         unixodbc \
         tdsodbc \
-        odbc-postgresql \
-        curl=7.81.0-1ubuntu1.17 \
-        less=590-1ubuntu0.22.04.3 \
-        libc6=2.35-0ubuntu3.8 \
-        libc-bin=2.35-0ubuntu3.8 \
-        libcurl3-gnutls=7.81.0-1ubuntu1.17 \
-        libglib2.0-0=2.72.4-0ubuntu2.3 \
-        libglib2.0-data=2.72.4-0ubuntu2.3 \
-        libkrb5-3=1.19.2-2ubuntu0.4 \
-        libk5crypto3=1.19.2-2ubuntu0.4 \
-        libnghttp2-14=1.43.0-1ubuntu0.2 \
-        libpython3.10-minimal=3.10.12-1~22.04.5 \
-        locales=2.35-0ubuntu3.8 \
-        openssh-client=1:8.9p1-3ubuntu0.10 \
-        openssl=3.0.2-0ubuntu1.17 \
-        python3-zipp=1.0.0-3ubuntu0.1 \
-        python3.10=3.10.12-1~22.04.5 && \
+        odbc-postgresql && \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG BUILD_DATE


### PR DESCRIPTION
This PR updates the member's base Docker image from `phusion/baseimage:jammy-1.0.4` to `ubuntu:oracular`. The new image is smaller in size and, for now, has no detected vulnerabilities.